### PR TITLE
WIP: Apple silicon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,6 @@ If you are looking for the regular dotfiles, check [home/config](home/config).
 
 ## MacOS
 
-If using Apple Silicon Processor:
-1. Enable Rosetta:
-```sh
-$ /usr/sbin/softwareupdate --install-rosetta --agree-to-license
-``` 
-2. Duplicate `Terminal` App and rename the duplicate to `Terminal (Rosetta)`.
-3. Under `Get Info`, set the application to open using Rosetta.
-4. Open Terminal Rosetta.
-
 Now the setup itself:
 
 1. Register your's machine's SSH key on Github, replace `<email-address>` with your email address:
@@ -41,24 +32,29 @@ $ (cat "$HOME"/.ssh/id_ed25519.pub | pbcopy) && open https://github.com/settings
 $ mkdir -p "$HOME"/workspace && cd "$_" && git clone git@github.com:bphenriques/dotfiles.git && cd dotfiles
 ```
 
-3. Bootstrap the dependencies and sync the nix configuration:
+3. Bootstrap the dependencies:
 ```sh
 $ make bootstrap sync-<host>
 ```
 
-4. Import your public GPG key:
+4. Apply flake:
+```sh
+$ make sync-<host>
+```
+
+5. Import your public GPG key:
 ```sh
 $ gpg --import <public-key-location>
 ```
 
-5. Import your private GPG key:
+6. Import your private GPG key:
 ``` sh
 $ base64 -d <private-key-location> | gpg --import
 ```
 
 **Warning**: Do not forget to delete the GPG keys.
 
-1. Reboot!
+Reboot!
 
 # Updating
 
@@ -67,6 +63,29 @@ $ make update sync-<host>
 ```
 
 This will update both `flake.lock` and Doom Emacs. Check if everything is stable before commiting.
+
+# Uninstall
+
+## MacOS
+1. Remove [nix-darwin](https://github.com/LnL7/nix-darwin#uninstalling).
+2. `rm -rf $HOME/{.nix-channels,.nix-defexpr,.nix-profile,.config/nixpkgs}`
+3. Reboot.
+4. (MacOS): On Disk Utility, unmount Nix Storage
+5. Remove Nix Storage
+6. Check that `/etc/synthetic.conf` does not contain Nix. If so, remove it. Reboot.
+7. `sudo rm -rf /nix`
+
+If on multi-user installation:
+```
+for num in {1..32}; do sudo dscl . -delete /Users/nixbld$num; done
+sudo dscl . -delete /Groups/nixbld
+```
+
+Sources:
+- https://github.com/NixOS/nix/issues/1402
+- https://gist.github.com/expelledboy/c00aebb004b178cf78b2c9b344526ff6
+
+Brew tip: Remove everything from brew: `brew list | xargs brew uninstall --force`
 
 # Troubleshooting
 

--- a/flake.lock
+++ b/flake.lock
@@ -7,16 +7,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1622060422,
-        "narHash": "sha256-hPVlvrAyf6zL7tTx0lpK+tMxEfZeMiIZ/A2xaJ41WOY=",
-        "owner": "lnl7",
+        "lastModified": 1629233952,
+        "narHash": "sha256-wQwGZBna9n1fypwE/3lxMMs8nmMCHnrtgy1QeznPUN0=",
+        "owner": "bphenriques",
         "repo": "nix-darwin",
-        "rev": "007d700e644ac588ad6668e6439950a5b6e2ff64",
+        "rev": "dc99864deebe9e0ade174c62a3cd038eac8be32b",
         "type": "github"
       },
       "original": {
-        "owner": "lnl7",
-        "ref": "master",
+        "owner": "bphenriques",
+        "ref": "pass-system",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1628946811,
-        "narHash": "sha256-u/A1RzWyP88zbMwVFJ41BAkh9BTLbSLfCigrGAgyZKQ=",
+        "lastModified": 1629151238,
+        "narHash": "sha256-brMNLZLz8u9+6tSJ9J8dWkp1sT2mFiO3g2jQZVu+rtQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "72f3bc6fa461a2899a06c87c137c7135e410e387",
+        "rev": "ad0fc085c7b954d5813a950cf0db7143e6b049e3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable"; # Unstable for some packages.
 
     # MacOS inputs
-    darwin.url = "github:lnl7/nix-darwin/master";
+    darwin.url = "github:bphenriques/nix-darwin/pass-system";       # Keep while https://github.com/LnL7/nix-darwin/issues/319 is not fixed.
     darwin.inputs.nixpkgs.follows = "nixpkgs";                      # Ensure versions are consistent.
 
     # Home inputs
@@ -23,6 +23,7 @@
           (
             final: prev: {
               unstable = nixpkgs-unstable.legacyPackages.${prev.system}; # Make available unstable channel.
+              x86-pkgs = nixpkgs-unstable.legacyPackages.x86_64-darwin; # Make available intel packages
             }
           )
         ];

--- a/home/shared-home.nix
+++ b/home/shared-home.nix
@@ -13,11 +13,11 @@
     fd          # A better `find`.
     gnupg       # To manage GNUPG keys.
     pinentry    # To input keys.
-    
+
     # Other tools that I use from time to time:
     httpie      # Alternative to curl. Use with `http`.
-    ngrok       # Tunneling.
-    hugo        # Blogging. TODO: Move to project instead.
+    # x86-pkgs.ngrok       # Tunneling. FIXME: Doesn't support Apple Silicon
+    hugo        # Blogging. FIXME: Move to project instead.
     parallel    # Useful to parallelize tasks.
 
     # Tools I am experimenting:
@@ -33,15 +33,10 @@
     ./config/zsh
     ./config/fzf
     ./config/tmux
-    
+
     # Packages I am experimenting with.
-    ./config/vscodium
+    # ./config/vscodium
   ];
 
-  # This value determines the Home Manager release that your configuration is compatible with. This
-  # helps avoid breakage when a new Home Manager release introduces backwards incompatible changes.
-  #
-  # You can update Home Manager without changing this value. See the Home Manager release notes for
-  # a list of state version changes in each release.
-  home.stateVersion = "21.11";
+  home.stateVersion = "21.05";
 }

--- a/hosts/work-macos.nix
+++ b/hosts/work-macos.nix
@@ -25,7 +25,6 @@
 
   # Ugly bit: This host uses Apple M1 Silicon Processor. This means that some apps have to be installed manually.
   system.activationScripts.postUserActivation.text = ''
-    echo
     echo "Using Apple Silicon requires some apps to be manually installed:"
     echo "Manually install Docker: https://docs.docker.com/docker-for-mac/apple-silicon/"
     echo "Manually install IntelliJ: https://www.jetbrains.com/idea/download/#section=mac"

--- a/lib/enable-flakes.nix
+++ b/lib/enable-flakes.nix
@@ -3,6 +3,10 @@
 {
   nix = {
     package = pkgs.nixFlakes;
-    extraOptions = "experimental-features = nix-command flakes";
+    extraOptions = ''
+      system = aarch64-darwin
+      extra-platforms = aarch64-darwin x86_64-darwin
+      experimental-features = nix-command flakes
+    '';
   };
 }

--- a/lib/nix-darwin-helpers.nix
+++ b/lib/nix-darwin-helpers.nix
@@ -11,6 +11,8 @@
   # $ nix build .#darwinConfigurations.<host-name>.system
   # $ ./result/sw/bin/darwin-rebuild switch --flake .#<host-name>
   mkMacOSHost = hostModule: darwin.lib.darwinSystem {
+    # system = "aarch64-darwin";
+    system = "x86_64-darwin";
     modules = [
       home-manager.darwinModules.home-manager
       ./enable-flakes.nix                                     # Can't be inline as the pkgs here does not include the nixFlakes attribute (unclear why).
@@ -19,7 +21,7 @@
         nixpkgs = nixpkgs;
 
         # Home-Manager
-        home-manager.useGlobalPkgs = true;                    # For consistency, use global pkgs configured via the system level nixpkgs options.        
+        home-manager.useGlobalPkgs = true;                    # For consistency, use global pkgs configured via the system level nixpkgs options.
         home-manager.useUserPackages = true;                  # Install packages defined in home-manager.
 
         # Nix-Darwin

--- a/macos/homebrew/shared-packages.nix
+++ b/macos/homebrew/shared-packages.nix
@@ -1,7 +1,13 @@
 {
   homebrew.enable = true;
-  homebrew.cleanup = "zap";
+  #homebrew.cleanup = "zap";
+
+  # TODO: https://github.com/macalinao/dotfiles/blob/4227de3084c7abcaf1139a1b49c9c1a2472a2a6f/nix/darwin/default.nix#L19
+  # if isM1 then "/opt/homebrew/bin" else "/usr/local/bin";
+  homebrew.brewPrefix = "/opt/homebrew/bin"; # "/usr/local/bin" for intel cpu
   
+  # Consider the following for personal stuff: https://github.com/macalinao/dotfiles/blob/4227de3084c7abcaf1139a1b49c9c1a2472a2a6f/nix/darwin/default.nix#L50
+
   imports = [
     ./emacs-package.nix
     ./jdk-packages.nix
@@ -13,6 +19,7 @@
   ];
 
   homebrew.brews = [
+    "wget"
     "dateutils"                 # Date utilities. Not supported currently by nix-pkgs.
     "plumber"                   # Useful utility for messaging queues.
   ];
@@ -22,6 +29,12 @@
     "alacritty"                 # Terminal.
     "vlc"                       # Media player.
     "vscodium"                  # Open-Source counter-part of Microsoft Visual Studio Code
-    "keybase"                   # E2E encrypted vauls and chats.
   ];
+
+  system.activationScripts.postUserActivation.text = ''
+    echo "----"
+    echo "What is my CPU?"
+    uname -m
+    echo "----"
+  '';
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,8 +1,12 @@
+# TODO: Check https://github.com/macalinao/dotfiles/blob/4227de3084c7abcaf1139a1b49c9c1a2472a2a6f/install.sh
+
+
 #!/bin/sh
 # shellcheck disable=SC2016,SC1091,SC1090
 #
 # Bootstraps the required dependencies for non-NixOS operating systems.
 #
+
 set -euf 
 SCRIPT_PATH="$(dirname "$0")"
 # shellcheck source=util.sh
@@ -31,12 +35,15 @@ install_nix_flakes() {
     if ! nix flake check 2>/dev/null; then 
         info 'Nix Flakes - Installing...'
         nix-env -iA nixpkgs.nixFlakes
-        mkdir -p "$XDG_CONFIG_HOME"/nix && touch "$XDG_CONFIG_HOME"/nix/nix.conf
-        append_if_absent 'experimental-features = nix-command flakes' "$XDG_CONFIG_HOME"/nix/nix.conf
     fi
+    mkdir -p "$XDG_CONFIG_HOME"/nix && touch "$XDG_CONFIG_HOME"/nix/nix.conf
+    append_if_absent 'experimental-features = nix-command flakes' "$XDG_CONFIG_HOME"/nix/nix.conf
     success 'Nix Flakes - Installed!'
 }
 
+# TODO: Check if Apple Silicon and install that as well
+## arch --arm64 zsh -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+## arch --x86_64 zsh -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 install_homebrew() {
     info 'Homebrew - Checking...'
     if ! command -v brew > /dev/null; then


### PR DESCRIPTION
WIP

---

Several blockages:
- Several dev packages do not support Apple Silicon (e.g., ghc)
- Nix Darwin does not allow passing the system which defaults to Intel CPUs: https://github.com/LnL7/nix-darwin/issues/319
- Some packages I could probably get back by using a custom nixpkgs location

Useful:
```
isAppleSilicon = (pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64);
```

Found some opportunities to clean-up which I can make elsewhere.