### PR TITLE
Move mkAppOpt to lib/builders.nix; remove dead copy from screenshot.nix

### DIFF
--- a/lib/builders.nix
+++ b/lib/builders.nix
@@ -1,5 +1,12 @@
 { lib, pkgs }:
 {
+  # Option type for app executables: accepts a package (extracts the main binary) or a raw string path.
+  mkAppOpt = default: lib.mkOption {
+    inherit default;
+    description = "";
+    type = lib.types.coercedTo lib.types.package lib.getExe lib.types.str;
+  };
+
   writeFuzzelDmenuApplication = {
     name,
     runtimeInputs ? [ ],

--- a/modules/home-manager/programs/screen-recorder.nix
+++ b/modules/home-manager/programs/screen-recorder.nix
@@ -4,12 +4,7 @@ let
   inherit (lib) nameValuePair;
 
   cfg = config.custom.programs.screen-recorder;
-
-  mkAppOpt = default: lib.mkOption {
-    inherit default;
-    description = "";
-    type = lib.types.coercedTo lib.types.package lib.getExe lib.types.str;
-  };
+  mkAppOpt = self.lib.builders.mkAppOpt;
 
   mkIcon = self.lib.builders.mkNerdFontIcon { textColor = config.lib.stylix.colors.withHashtag.base07; };
 

--- a/modules/home-manager/programs/screenshot.nix
+++ b/modules/home-manager/programs/screenshot.nix
@@ -5,12 +5,6 @@ let
 
   cfg = config.custom.programs.screenshot;
 
-  mkAppOpt = default: lib.mkOption {
-    inherit default;
-    description = "";
-    type = lib.types.coercedTo lib.types.package lib.getExe lib.types.str;
-  };
-
   mkIcon = self.lib.builders.mkNerdFontIcon { textColor = config.lib.stylix.colors.withHashtag.base07; };
 
   screenshot = lib.getExe cfg.package;


### PR DESCRIPTION
## Summary

- `mkAppOpt` was defined identically in both `screen-recorder.nix` and `screenshot.nix` (where it wasn't even used — dead code)
- Move it to `lib/builders.nix` alongside the other shared helpers
- Reference it from `screen-recorder.nix` via `self.lib.builders.mkAppOpt`
- Drop the unused definition from `screenshot.nix`