### PR TITLE
Extract get_icon helper in volume-osd to remove echo-n boilerplate

### DIFF
--- a/packages/desktop/volume-osd/script.sh
+++ b/packages/desktop/volume-osd/script.sh
@@ -43,39 +43,42 @@ friendly_source_name() {
   esac
 }
 
+# Echoes the icon stored in the named env var. Usage: get_icon OSD_VOLUME_HEADSET_ICON
+get_icon() { local var="$1"; echo -n "${!var}"; }
+
 get_sink_icon() {
   local device_type="$1"
   case "$device_type" in
-    internal)     echo -n "${OSD_VOLUME_INTERNAL_SPEAKERS_ICON}" ;;
-    external)     echo -n "${OSD_VOLUME_EXTERNAL_SPEAKERS_ICON}" ;;
-    headset)      echo -n "${OSD_VOLUME_HEADSET_ICON}" ;;
-    headphones)   echo -n "${OSD_VOLUME_HEADPHONES_ICON}" ;;
+    internal)   get_icon OSD_VOLUME_INTERNAL_SPEAKERS_ICON ;;
+    external)   get_icon OSD_VOLUME_EXTERNAL_SPEAKERS_ICON ;;
+    headset)    get_icon OSD_VOLUME_HEADSET_ICON ;;
+    headphones) get_icon OSD_VOLUME_HEADPHONES_ICON ;;
   esac
 }
 
 get_sink_mute_icon() {
   local device_type="$1"
   case "$device_type" in
-    internal)     echo -n "${OSD_VOLUME_INTERNAL_SPEAKERS_MUTE_ICON}" ;;
-    external)     echo -n "${OSD_VOLUME_EXTERNAL_SPEAKERS_MUTE_ICON}" ;;
-    headset)      echo -n "${OSD_VOLUME_HEADSET_MUTE_ICON}" ;;
-    headphones)   echo -n "${OSD_VOLUME_HEADPHONES_MUTE_ICON}" ;;
+    internal)   get_icon OSD_VOLUME_INTERNAL_SPEAKERS_MUTE_ICON ;;
+    external)   get_icon OSD_VOLUME_EXTERNAL_SPEAKERS_MUTE_ICON ;;
+    headset)    get_icon OSD_VOLUME_HEADSET_MUTE_ICON ;;
+    headphones) get_icon OSD_VOLUME_HEADPHONES_MUTE_ICON ;;
   esac
 }
 
 get_source_icon() {
   local device_type="$1"
   case "$device_type" in
-    internal)     echo -n "${OSD_VOLUME_MICROPHONE_ICON}" ;;
-    headset)      echo -n "${OSD_VOLUME_HEADSET_ICON}" ;;
+    internal) get_icon OSD_VOLUME_MICROPHONE_ICON ;;
+    headset)  get_icon OSD_VOLUME_HEADSET_ICON ;;
   esac
 }
 
 get_source_mute_icon() {
   local device_type="$1"
   case "$device_type" in
-    internal)     echo -n "$OSD_VOLUME_MICROPHONE_MUTE_ICON" ;;
-    headset)      echo -n "$OSD_VOLUME_HEADSET_MUTE_ICON" ;;
+    internal) get_icon OSD_VOLUME_MICROPHONE_MUTE_ICON ;;
+    headset)  get_icon OSD_VOLUME_HEADSET_MUTE_ICON ;;
   esac
 }
 


### PR DESCRIPTION
## Summary

- All four icon getter functions (`get_sink_icon`, `get_sink_mute_icon`, `get_source_icon`, `get_source_mute_icon`) repeated the same `echo -n "${VAR}"` pattern in every case arm
- Introduce `get_icon VAR_NAME` that resolves a variable by name via indirect expansion (`${!var}`)
- Each case arm now just declares which env var to use — no more `echo -n` boilerplate