### PR TITLE
Fix mkEnableOption description for custom.programs.niri

### DIFF
--- a/modules/home-manager/programs/niri.nix
+++ b/modules/home-manager/programs/niri.nix
@@ -15,7 +15,7 @@ let
 in
 {
   options.custom.programs.niri = {
-    enable = lib.mkEnableOption "programs-niri";
+    enable = lib.mkEnableOption "custom-niri";
 
     environment = lib.mkOption {
       description = "Environment variables to set in a niri session";


### PR DESCRIPTION
## Summary

- `niri.nix` used `"programs-niri"` as the `mkEnableOption` description
- All comparable desktop program modules use the `"custom-*"` prefix: `brightness-osd`, `mpc`, `screen-recorder`, `screenshot`, `session`, `volume-osd`
- Change to `"custom-niri"` for consistency